### PR TITLE
Update dead "Metrics reference list" link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -259,7 +259,7 @@ Open Liberty as a vendor supplies server component metrics when the [hotspot=mpM
 You can see the vendor-only metrics in the `metrics/vendor` endpoint.
 You see metrics from the runtime components, such as Web Application, ThreadPool and Session Management.
 Note that these metrics are specific to the Liberty application server. Different vendors may provide other metrics.
-Visit the https://openliberty.io/docs/ref/general/#metrics-catalog.html[Metrics reference list^] for more information.
+Visit the https://openliberty.io/docs/ref/general/#metrics-list.html[Metrics reference list^] for more information.
 
 // =================================================================================================
 // Building and running the application


### PR DESCRIPTION
The current "Metrics reference list" link points to a 404 page, this PR replaces the link with a working one.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>